### PR TITLE
Add support for insecure TLS certificates

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Core Info
-version=4.0.0-SNAPSHOT
+version=4.1.0-SNAPSHOT
 group=uk.ac.ox.softeng.maurodatamapper
 # Gradle
 gradleVersion=7.3.3

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/api/restful/client/BindingMauroDataMapperClient.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/api/restful/client/BindingMauroDataMapperClient.groovy
@@ -84,17 +84,17 @@ class BindingMauroDataMapperClient extends MauroDataMapperClient implements Data
         initialise()
     }
 
-    BindingMauroDataMapperClient(String baseUrl, String username, String password, Boolean insecureTls) {
+    BindingMauroDataMapperClient(String baseUrl, String username, String password, Boolean insecureTls = false) {
         super(baseUrl, username, password, insecureTls)
         initialise()
     }
 
-    BindingMauroDataMapperClient(String baseUrl, UUID apiKey, Boolean insecureTls) {
+    BindingMauroDataMapperClient(String baseUrl, UUID apiKey, Boolean insecureTls = false) {
         super(baseUrl, apiKey, insecureTls)
         initialise()
     }
 
-    BindingMauroDataMapperClient(String connectionName, String baseUrl, String username, String password, Boolean insecureTls) {
+    BindingMauroDataMapperClient(String connectionName, String baseUrl, String username, String password, Boolean insecureTls = false) {
         super(connectionName, baseUrl, username, password, insecureTls)
         initialise()
     }

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/api/restful/client/BindingMauroDataMapperClient.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/api/restful/client/BindingMauroDataMapperClient.groovy
@@ -84,18 +84,18 @@ class BindingMauroDataMapperClient extends MauroDataMapperClient implements Data
         initialise()
     }
 
-    BindingMauroDataMapperClient(String baseUrl, String username, String password) {
-        super(baseUrl, username, password)
+    BindingMauroDataMapperClient(String baseUrl, String username, String password, Boolean insecureTls) {
+        super(baseUrl, username, password, insecureTls)
         initialise()
     }
 
-    BindingMauroDataMapperClient(String baseUrl, UUID apiKey) {
-        super(baseUrl, apiKey)
+    BindingMauroDataMapperClient(String baseUrl, UUID apiKey, Boolean insecureTls) {
+        super(baseUrl, apiKey, insecureTls)
         initialise()
     }
 
-    BindingMauroDataMapperClient(String connectionName, String baseUrl, String username, String password) {
-        super(connectionName, baseUrl, username, password)
+    BindingMauroDataMapperClient(String connectionName, String baseUrl, String username, String password, Boolean insecureTls) {
+        super(connectionName, baseUrl, username, password, insecureTls)
         initialise()
     }
 

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/api/restful/client/MauroDataMapperClient.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/api/restful/client/MauroDataMapperClient.groovy
@@ -60,28 +60,28 @@ class MauroDataMapperClient implements Closeable {
         this(DEFAULT_CONNECTION_NAME, properties)
     }
 
-    MauroDataMapperClient(String baseUrl, String username, String password) {
-        this(DEFAULT_CONNECTION_NAME, baseUrl, username, password)
+    MauroDataMapperClient(String baseUrl, String username, String password, Boolean insecureTls) {
+        this(DEFAULT_CONNECTION_NAME, baseUrl, username, password, insecureTls)
     }
 
-    MauroDataMapperClient(String baseUrl, UUID apiKey) {
-        this(DEFAULT_CONNECTION_NAME, baseUrl, apiKey)
+    MauroDataMapperClient(String baseUrl, UUID apiKey, Boolean insecureTls) {
+        this(DEFAULT_CONNECTION_NAME, baseUrl, apiKey, insecureTls)
     }
 
     MauroDataMapperClient(String connectionName, Properties properties) {
         this(connectionName, properties.getProperty("client.baseUrl"), properties.getProperty("client.username"),
-             properties.getProperty("client.password"))
+                properties.getProperty("client.password"), Boolean.parseBoolean(properties.getProperty("client.insecure", "false")))
     }
 
-    MauroDataMapperClient(String connectionName, String baseUrl, String username, String password) {
+    MauroDataMapperClient(String connectionName, String baseUrl, String username, String password, Boolean insecureTls) {
         defaultConnectionName = connectionName
-        openConnection(connectionName, baseUrl, username, password)
+        openConnection(connectionName, baseUrl, username, password, insecureTls)
         initialiseServices()
     }
 
-    MauroDataMapperClient(String connectionName, String baseUrl, UUID apiKey) {
+    MauroDataMapperClient(String connectionName, String baseUrl, UUID apiKey, Boolean insecureTls) {
         defaultConnectionName = connectionName
-        openConnection(connectionName, baseUrl, apiKey)
+        openConnection(connectionName, baseUrl, apiKey, insecureTls)
         initialiseServices()
     }
     // Local only client
@@ -113,14 +113,14 @@ class MauroDataMapperClient implements Closeable {
         NAMED_CONNECTIONS[name]
     }
 
-    void openConnection(String name, String baseUrl, String username, String password) {
+    void openConnection(String name, String baseUrl, String username, String password, Boolean insecureTls) {
         closeConnection(name)
-        NAMED_CONNECTIONS[name] = new MauroDataMapperConnection(baseUrl, username, password)
+        NAMED_CONNECTIONS[name] = new MauroDataMapperConnection(baseUrl, username, password, insecureTls)
     }
 
-    void openConnection(String name, String baseUrl, UUID apiKey) {
+    void openConnection(String name, String baseUrl, UUID apiKey, Boolean insecureTls) {
         closeConnection(name)
-        NAMED_CONNECTIONS[name] = new MauroDataMapperConnection(baseUrl, apiKey)
+        NAMED_CONNECTIONS[name] = new MauroDataMapperConnection(baseUrl, apiKey, insecureTls)
     }
 
     void openConnection(String name, Properties properties) {

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/api/restful/client/MauroDataMapperClient.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/api/restful/client/MauroDataMapperClient.groovy
@@ -60,11 +60,11 @@ class MauroDataMapperClient implements Closeable {
         this(DEFAULT_CONNECTION_NAME, properties)
     }
 
-    MauroDataMapperClient(String baseUrl, String username, String password, Boolean insecureTls) {
+    MauroDataMapperClient(String baseUrl, String username, String password, Boolean insecureTls = false) {
         this(DEFAULT_CONNECTION_NAME, baseUrl, username, password, insecureTls)
     }
 
-    MauroDataMapperClient(String baseUrl, UUID apiKey, Boolean insecureTls) {
+    MauroDataMapperClient(String baseUrl, UUID apiKey, Boolean insecureTls = false) {
         this(DEFAULT_CONNECTION_NAME, baseUrl, apiKey, insecureTls)
     }
 
@@ -73,13 +73,13 @@ class MauroDataMapperClient implements Closeable {
                 properties.getProperty("client.password"), Boolean.parseBoolean(properties.getProperty("client.insecure", "false")))
     }
 
-    MauroDataMapperClient(String connectionName, String baseUrl, String username, String password, Boolean insecureTls) {
+    MauroDataMapperClient(String connectionName, String baseUrl, String username, String password, Boolean insecureTls = false) {
         defaultConnectionName = connectionName
         openConnection(connectionName, baseUrl, username, password, insecureTls)
         initialiseServices()
     }
 
-    MauroDataMapperClient(String connectionName, String baseUrl, UUID apiKey, Boolean insecureTls) {
+    MauroDataMapperClient(String connectionName, String baseUrl, UUID apiKey, Boolean insecureTls = false) {
         defaultConnectionName = connectionName
         openConnection(connectionName, baseUrl, apiKey, insecureTls)
         initialiseServices()

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/api/restful/connection/MauroDataMapperConnection.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/api/restful/connection/MauroDataMapperConnection.groovy
@@ -17,6 +17,7 @@
  */
 package uk.ac.ox.softeng.maurodatamapper.api.restful.connection
 
+import io.micronaut.http.ssl.ClientSslConfiguration
 import uk.ac.ox.softeng.maurodatamapper.api.restful.client.ClientUser
 import uk.ac.ox.softeng.maurodatamapper.api.restful.client.RestClientInterface
 import uk.ac.ox.softeng.maurodatamapper.api.restful.connection.endpoint.MauroDataMapperEndpoint
@@ -56,13 +57,13 @@ class MauroDataMapperConnection implements DataBinder, Closeable, RestClientInte
     HttpClient client
     NettyCookie currentCookie
 
-    MauroDataMapperConnection(String baseUrl, String username, String password) {
-        setClient(baseUrl)
+    MauroDataMapperConnection(String baseUrl, String username, String password, Boolean insecureTls = false) {
+        setClient(baseUrl, insecureTls)
         login(username, password)
     }
 
-    MauroDataMapperConnection(String baseUrl, UUID apiKey) {
-        setClient(baseUrl)
+    MauroDataMapperConnection(String baseUrl, UUID apiKey, Boolean insecureTls = false) {
+        setClient(baseUrl, insecureTls)
         this.apiKey = apiKey
         getUserDetails()
     }
@@ -72,15 +73,21 @@ class MauroDataMapperConnection implements DataBinder, Closeable, RestClientInte
         getUserDetails()
     }
 
-
-
-    void setClient(String baseUrl) {
+    void setClient(String baseUrl, Boolean insecureTls) {
         this.baseUrl = baseUrl + "/api/"
+
+        if(insecureTls) log.warn("Insecure TLS is enabled!! Do not use this option when connecting to production instances")
+
         this.client = new DefaultHttpClient(new URI(this.baseUrl),
                                             new DefaultHttpClientConfiguration().with {
                                                 setReadTimeout(Duration.ofMinutes(30))
                                                 setReadIdleTimeout(Duration.ofMinutes(30))
                                                 setMaxContentLength(1000 * 1024 * 1024)
+                                                setSslConfiguration(new ClientSslConfiguration().with{
+                                                    enabled = true
+                                                    insecureTrustAllCertificates = insecureTls
+                                                    it
+                                                })
                                                 it
                                             })
 

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/utils/commandline/MdmConnectionOptions.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/utils/commandline/MdmConnectionOptions.groovy
@@ -56,14 +56,20 @@ class MdmConnectionOptions extends BasicCommandOptions {
     )
     String clientApiKey
 
+    @CommandLine.Option(
+            names = [ "-i", "--insecure", "--client.insecure" ],
+            description = [ "Allow insecure TLS connections (eg, self-signed certificates or mismatched hostnames)"],
+            defaultValue = "false"
+    )
+    Boolean clientInsecureTls
 
 
     BindingMauroDataMapperClient getBindingMauroDataMapperClient() {
         if(clientUsername && clientPassword) {
-            return new BindingMauroDataMapperClient(clientBaseUrl.toString(), clientUsername, new String(clientPassword))
+            return new BindingMauroDataMapperClient(clientBaseUrl.toString(), clientUsername, new String(clientPassword), clientInsecureTls)
         } else if (clientApiKey) {
             UUID clientApiKeyUUID = UUID.fromString(clientApiKey)
-            return new BindingMauroDataMapperClient(clientBaseUrl.toString(), clientApiKeyUUID)
+            return new BindingMauroDataMapperClient(clientBaseUrl.toString(), clientApiKeyUUID, clientInsecureTls)
         } else {
             log.error("username / password or apiKey must be set")
             return null


### PR DESCRIPTION
Why: ephemeral/throwaway cloud environments typically use wildcarded or self-signed certificates during solution development.